### PR TITLE
Log error threw by `intersect`

### DIFF
--- a/lerna-semver-sync.js
+++ b/lerna-semver-sync.js
@@ -71,7 +71,7 @@ function getAllDependencies (packagePaths) {
     }, {});
 }
 
-function getCommonRange (compoundRanges, name) {
+function getCommonRange (compoundRanges) {
     const majorVersions = compoundRanges.reduce((result, compoundRange) => {
         compoundRange.split('||').map(range => range.trim()).forEach(range => {
             if (isExactRange(range)) {
@@ -99,7 +99,7 @@ function getCommonRange (compoundRanges, name) {
 
 function getCommonRanges (allDependencies) {
     return reduce(allDependencies, (result, ranges, name) => {
-        result[name] = getCommonRange(ranges, name);
+        result[name] = getCommonRange(ranges);
         return result;
     }, {});
 }

--- a/lerna-semver-sync.js
+++ b/lerna-semver-sync.js
@@ -71,7 +71,7 @@ function getAllDependencies (packagePaths) {
     }, {});
 }
 
-function getCommonRange (compoundRanges) {
+function getCommonRange (compoundRanges, name) {
     const majorVersions = compoundRanges.reduce((result, compoundRange) => {
         compoundRange.split('||').map(range => range.trim()).forEach(range => {
             if (isExactRange(range)) {
@@ -86,7 +86,11 @@ function getCommonRange (compoundRanges) {
     }, {});
 
     forEach(majorVersions, (ranges, majorVersion) => {
-        majorVersions[majorVersion] = intersect(...ranges);
+        try {
+            majorVersions[majorVersion] = intersect(...ranges);
+        } catch(e) {
+            console.log(`error in intersect version on package: ${name}`);
+        }
     });
 
     return majorVersions;
@@ -94,7 +98,7 @@ function getCommonRange (compoundRanges) {
 
 function getCommonRanges (allDependencies) {
     return reduce(allDependencies, (result, ranges, name) => {
-        result[name] = getCommonRange(ranges);
+        result[name] = getCommonRange(ranges, name);
         return result;
     }, {});
 }

--- a/lerna-semver-sync.js
+++ b/lerna-semver-sync.js
@@ -89,7 +89,8 @@ function getCommonRange (compoundRanges, name) {
         try {
             majorVersions[majorVersion] = intersect(...ranges);
         } catch(e) {
-            console.log(`error in intersect version on package: ${name}`);
+            // bypass the error happened in intersect function
+            // let the `duplicates` object return by Sync funtion handle the warning
         }
     });
 


### PR DESCRIPTION
Since you throw an error from `interset` (https://github.com/snyamathi/semver-intersect/blob/master/src/semver-intersect.js#L73)
I think it would be better if we can see which package can't meet the common range and keep going.